### PR TITLE
Process quoted-printable on python encoding

### DIFF
--- a/anti-non-ubc.py
+++ b/anti-non-ubc.py
@@ -4,6 +4,7 @@ from email.Parser import Parser
 from sys import stdin, stdout
 import re
 import base64
+import quopri
 
 plaintext_re = re.compile(r"\[CAUTION: Non-UBC Email\]\n\s*\n", re.MULTILINE)
 html_re = re.compile(r'<table style="border-collapse: collapse; padding-left: 0px;"><tbody><tr><td><font style="font-family: Arial, sans-serif; font-size: 12px; font-style: normal; font-weight: normal; color: #000000; background-color: #FFECB3; line-height: 1.6; padding: 3px;">\[<strong>CAUTION:</strong> Non-UBC Email\]</font></td></tr></tbody></table>', re.MULTILINE)
@@ -12,6 +13,8 @@ def filter(part):
   new_body = re.sub(html_re,'',re.sub(plaintext_re,'',part.get_payload(decode=True)))
   if part.__getitem__("Content-Transfer-Encoding") == "base64":
     return base64.b64encode(new_body)
+  elif part.__getitem__("Content-Transfer-Encoding") == "quoted-printable":
+    return quopri.encodestring(new_body) 
   else:
     return new_body
 

--- a/testfiles/quoted-printable.eml
+++ b/testfiles/quoted-printable.eml
@@ -1,0 +1,19 @@
+[Return-Path: <user@localhost>
+From: User <user@localhost>
+Content-Type: multipart/alternative;
+	boundary="Apple-Mail=_7160A67B-ADDC-4878-B467-F1CA2A8F2A40"
+Mime-Version: 1.0 (Mac OS X Mail 14.0 \(3654.60.0.2.21\))
+Subject: Basic Test
+Date: Thu, 11 Feb 2021 13:49:51 -0800
+To: other <other@localhost>
+X-Mailer: Apple Mail (2.3654.60.0.2.21)
+
+
+--Apple-Mail=_7160A67B-ADDC-4878-B467-F1CA2A8F2A40
+Content-Transfer-Encoding: quoted-printable
+Content-Type: text/plain;
+	charset=utf-8
+
+https://www.youtube.com/watch?v=3D8c0_Lzb1CJw&t=3D4736
+
+--Apple-Mail=_7160A67B-ADDC-4878-B467-F1CA2A8F2A40--

--- a/tests.sh
+++ b/tests.sh
@@ -25,8 +25,11 @@ FILE="testfiles/quoted-printable.eml"
 # Test 1 : anti-non-ubc idempotent for quoted-printable
 
 python anti-non-ubc.py <$FILE | diff -a -w -B $FILE -
-check_errcode 0 "FAIL: quoted-printable must be idempotent"
+check_errcode 0 "FAIL: quoted-printable must be idempotent in anti-non-ubc"
 
+# Test 2 : un_hxxps idempotent for quoted-printable
+python un_hxxps.py <$FILE | diff -a -w -B $FILE -
+check_errcode 0 "FAIL: quoted-printable must be idempotent in un_hxxps"
 
 
 

--- a/tests.sh
+++ b/tests.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Test for repeatable outcomes.
+# Would have preferred to do this in python, but
+# with the current style of scripts it becomes much harder to read.
+
+FILE="testfiles/quoted-printable.eml"
+PASS=0
+FAIL=0
+
+# Run test 1
+
+python anti-non-ubc.py <$FILE | diff -a -w -B $FILE -
+ERRCODE=$?
+
+if [ $ERRCODE -eq 0 ]
+then
+    ((PASS++))
+else
+    echo "FAIL: quoted-printable must be idempotent"
+    ((FAIL++))
+fi
+
+echo "---------"
+echo "Tests Passed: $PASS.  Tests Failed: $FAIL"
+

--- a/tests.sh
+++ b/tests.sh
@@ -4,22 +4,31 @@
 # Would have preferred to do this in python, but
 # with the current style of scripts it becomes much harder to read.
 
-FILE="testfiles/quoted-printable.eml"
 PASS=0
 FAIL=0
+check_errcode() {
+    ERRCODE=$?
 
-# Run test 1
+    if [ $ERRCODE -eq $1 ]
+    then
+        ((PASS++))
+    else
+        echo "$2"
+        ((FAIL++))
+    fi
+}
+    
+
+
+FILE="testfiles/quoted-printable.eml"
+
+# Test 1 : anti-non-ubc idempotent for quoted-printable
 
 python anti-non-ubc.py <$FILE | diff -a -w -B $FILE -
-ERRCODE=$?
+check_errcode 0 "FAIL: quoted-printable must be idempotent"
 
-if [ $ERRCODE -eq 0 ]
-then
-    ((PASS++))
-else
-    echo "FAIL: quoted-printable must be idempotent"
-    ((FAIL++))
-fi
+
+
 
 echo "---------"
 echo "Tests Passed: $PASS.  Tests Failed: $FAIL"

--- a/tests.sh
+++ b/tests.sh
@@ -28,7 +28,7 @@ python anti-non-ubc.py <$FILE | diff -a -w -B $FILE -
 check_errcode 0 "FAIL: quoted-printable must be idempotent in anti-non-ubc"
 
 # Test 2 : un_hxxps idempotent for quoted-printable
-python un_hxxps.py <$FILE | diff -a -w -B $FILE -
+python un-hxxps.py <$FILE | diff -a -w -B $FILE -
 check_errcode 0 "FAIL: quoted-printable must be idempotent in un_hxxps"
 
 

--- a/un-hxxps.py
+++ b/un-hxxps.py
@@ -4,11 +4,14 @@ from email.Parser import Parser
 from sys import stdin, stdout
 import re
 import base64
+import quopri
 
 def filter(part):
   new_body = re.sub(r'hxxp(s?)://',r'http\1://',part.get_payload(decode=True))
   if part.__getitem__("Content-Transfer-Encoding") == "base64":
     return base64.b64encode(new_body)
+  elif part.__getitem__("Content-Transfer-Encoding") == "quoted-printable":
+    return quopri.encodestring(new_body) 
   else:
     return new_body
 


### PR DESCRIPTION
Just like for `base64`, when `quoted-printable` content transfer encoding is set, it must be preserved.

Fixes #3. 